### PR TITLE
fix: wrong detection of an object type

### DIFF
--- a/src/main/java/org/trie4j/io/TrieWriter.java
+++ b/src/main/java/org/trie4j/io/TrieWriter.java
@@ -153,7 +153,7 @@ public class TrieWriter implements Constants {
         } else if (sbv instanceof BytesRank1OnlySuccinctBitVector) {
             dos.writeShort(TYPE_SBV_RANK1ONLY);
             writeRank1OnlySuccinctBitVector((BytesRank1OnlySuccinctBitVector) sbv);
-        } else if (sbv instanceof BytesRank1OnlySuccinctBitVector) {
+        } else if (sbv instanceof LongsSuccinctBitVector) {
             dos.writeShort(TYPE_SBV_LONGS);
             writeLongsSuccinctBitVector((LongsSuccinctBitVector) sbv);
         } else {


### PR DESCRIPTION
- fix a problem that is impossible to cast from org.trie4j.bv.BytesRank1OnlySuccinctBitVector to org.trie4j.bv.LongsSuccinctBitVector at org.trie4j.io.TrieWriter.writeSuccinctBitVector(SuccinctBitVector)
- This looks a typo of instanceof check